### PR TITLE
Update CI badge to link to workflow page

### DIFF
--- a/index.md
+++ b/index.md
@@ -154,7 +154,8 @@ Pantry Pal is based upon the ICS Software Engineering [Next.js Application Templ
 
 ---
 ## Continuous Integration
-![ci-badge](https://github.com/pantry-pals/pantry-pal/workflows/pantry-pals/badge.svg)
+[![ci-badge](https://github.com/pantry-pals/pantry-pal/workflows/pantry-pals/badge.svg)](https://github.com/pantry-pals/pantry-pal/actions/workflows/ci.yml)
+
 
 ---
 ## Development Team


### PR DESCRIPTION
Changed the CI badge in index.md to link directly to the GitHub Actions workflow page for easier access to build status and logs.