### PR TITLE
Update milestone links to project board titles

### DIFF
--- a/index.md
+++ b/index.md
@@ -189,14 +189,14 @@ Pantry Pal is based upon the ICS Software Engineering [Next.js Application Templ
   * [Milestone 7 Progress](#milestone-7-progress)
 
 ### Milestone 1 Progress
-[Milestone 1](https://github.com/orgs/pantry-pals/projects/2)
+[Milestone 1 Project Board](https://github.com/orgs/pantry-pals/projects/2)
 
 ![Pantry App Screenshot](assets/m1/pantry_pals_homepage.png)
 ![Pantry App Inventory_Screenshot](assets/m1/inventory.png)
 ![Pantry App ShoppingList_Screenshot](assets/m3/m3_shopping_list.png)
 
 ### Milestone 2 Progress
-[Milestone 2](https://github.com/orgs/pantry-pals/projects/7)
+[Milestone 2 Project Board](https://github.com/orgs/pantry-pals/projects/7)
 
 ![Pantry Pals Landing Page](assets/m2/m2_pantry_pals_landing.png)
 ![Pantry Pals Sign In Page](assets/m2/m2_signin_page.png)
@@ -207,7 +207,7 @@ Pantry Pal is based upon the ICS Software Engineering [Next.js Application Templ
 ![Pantry Pals Recipe Page](assets/m2/M2_recipePage.png)
 
 ### Milestone 3 Progress
-[Milestone 3](https://github.com/orgs/pantry-pals/projects/10)
+[Milestone 3 Project Board](https://github.com/orgs/pantry-pals/projects/10)
 
 ![M3 Landing Page](assets/m3/m3_landing.png)
 ![M3 Pantry Page Table](assets/m3/m3_pantry1.png)
@@ -220,7 +220,7 @@ Pantry Pal is based upon the ICS Software Engineering [Next.js Application Templ
 ![Mockup idea](assets/m1/Dashboard_Mock_Up.png)
 
 ### Milestone 4 Progress
-[Milestone 4](https://github.com/orgs/pantry-pals/projects/11)
+[Milestone 4 Project Board](https://github.com/orgs/pantry-pals/projects/11)
 
 ![M4 Landing Page](assets/m4/m4_landing.png)
 ![M4 Dashboard Page](assets/m4/m4_dashboard.png)
@@ -237,7 +237,7 @@ Pantry Pal is based upon the ICS Software Engineering [Next.js Application Templ
 ![M4 Recipes Page 2](assets/m4/m4_recipes2.png)
 
 ### Milestone 5 Progress
-[Milestone 5](https://github.com/orgs/pantry-pals/projects/12)
+[Milestone 5 Project Board](https://github.com/orgs/pantry-pals/projects/12)
 
 ![M5 Dashboard Page](assets/m5/m5_dashboard.png)
 ![M5 Pantry Page Table](assets/m5/m5_pantry_table.png)
@@ -254,7 +254,7 @@ Pantry Pal is based upon the ICS Software Engineering [Next.js Application Templ
 ![M5 Add To Shopping List from List View](assets/m5/m5_addtoshoppinglist2.png)
 
 ### Milestone 6 Progress
-[Milestone 6](https://github.com/orgs/pantry-pals/projects/13)
+[Milestone 6 Project Board](https://github.com/orgs/pantry-pals/projects/13)
 
 ![M6 Pantry Page Table](assets/m6/m6_pantry_table.png)
 ![M6 Pantry Page Cards](assets/m6/m6_pantry_cards.png)
@@ -268,7 +268,7 @@ Pantry Pal is based upon the ICS Software Engineering [Next.js Application Templ
 ![M6 View Shopping List](assets/m6/m6_view_shopping_list.png)
 
 ### Milestone 7 Progress
-[Milestone 7](https://github.com/orgs/pantry-pals/projects/14)
+[Milestone 7 Project Board](https://github.com/orgs/pantry-pals/projects/14)
 
 
 


### PR DESCRIPTION
Renamed milestone links to 'Project Board' for clarity and consistency across all milestone sections in index.md.